### PR TITLE
Apply default filters even if params are empty or nil

### DIFF
--- a/lib/rack/reducer/reduction.rb
+++ b/lib/rack/reducer/reduction.rb
@@ -22,9 +22,9 @@ module Rack
       #   a Rack-compatible params hash
       # @return +@dataset+ with the matching filters applied
       def apply(params)
-        if !params || params.empty?
-          return @dataset if @default_filters.empty?
+        return @dataset if !params.present? && @default_filters.empty?
 
+        if !params.present?
           filters = @default_filters
           symbolized_params = {}
         else

--- a/lib/rack/reducer/reduction.rb
+++ b/lib/rack/reducer/reduction.rb
@@ -12,6 +12,7 @@ module Rack
       def initialize(dataset, *filters)
         @dataset = dataset
         @filters = filters
+        @default_filters = filters.select{|filter| filter.required_argument_names.empty?}
       end
 
       # Run +@filters+ against the params argument
@@ -19,10 +20,16 @@ module Rack
       #   a Rack-compatible params hash
       # @return +@dataset+ with the matching filters applied
       def apply(params)
-        return @dataset if !params || params.empty?
+        if !params || params.empty?
+          return @dataset if @default_filters.empty?
+          filters = @default_filters
+          symbolized_params = Hash.new
+        else
+          filters = @filters
+          symbolized_params = params.to_unsafe_h.symbolize_keys
+        end
 
-        symbolized_params = params.to_unsafe_h.symbolize_keys
-        @filters.reduce(@dataset) do |data, filter|
+        filters.reduce(@dataset) do |data, filter|
           next data unless filter.satisfies?(symbolized_params)
 
           data.instance_exec(

--- a/lib/rack/reducer/reduction.rb
+++ b/lib/rack/reducer/reduction.rb
@@ -12,7 +12,9 @@ module Rack
       def initialize(dataset, *filters)
         @dataset = dataset
         @filters = filters
-        @default_filters = filters.select{|filter| filter.required_argument_names.empty?}
+        @default_filters = filters.select do |filter|
+          filter.required_argument_names.empty?
+        end
       end
 
       # Run +@filters+ against the params argument
@@ -22,8 +24,9 @@ module Rack
       def apply(params)
         if !params || params.empty?
           return @dataset if @default_filters.empty?
+
           filters = @default_filters
-          symbolized_params = Hash.new
+          symbolized_params = {}
         else
           filters = @filters
           symbolized_params = params.to_unsafe_h.symbolize_keys

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -17,7 +17,7 @@ module Fixtures
     ->(name:) {
       select { |item| item[:name].match(/#{name}/i) }
     },
-    ->(sort:) {
+    ->(sort: 'name') {
       sort_by { |item| item[sort.to_sym] }
     },
     ->(releases:) {

--- a/spec/reducer_spec.rb
+++ b/spec/reducer_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Rack::Reducer do
     end
   end
 
-  it 'can sort' do
+  it 'can override default params' do
     get '/artists?sort=genre' do |response|
       genre = response.json[0]['genre']
       expect(genre).to eq('alt-soul')

--- a/spec/reducer_spec.rb
+++ b/spec/reducer_spec.rb
@@ -64,10 +64,17 @@ RSpec.describe Rack::Reducer do
     expect(Fixtures::ArtistReducer.apply(nil)).to be_truthy
   end
 
+  it 'applies default filters' do
+    get '/artists' do |response|
+      name = response.json[0]['name']
+      expect(name).to eq('Björk')
+    end
+  end
+
   it 'can sort' do
-    get '/artists?order=genre' do |response|
+    get '/artists?sort=genre' do |response|
       genre = response.json[0]['genre']
-      expect(genre).to eq('alternative')
+      expect(genre).to eq('alt-soul')
     end
   end
 


### PR DESCRIPTION
Hi @chrisfrank 

I created a quick PR based on https://github.com/chrisfrank/rack-reducer/issues/6

This should keep the original performance with no defaults defined and just iterates through default filters when params are empty. Added a new benchmark for that. Maybe there is a way to optimize this even more?