### PR TITLE
Fix Rails loading stale data on filterless queries (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2019-10-05
+
+### Fixed
+- #11: Refresh dataset on every request in Rails apps (@chase439)
+- #10: Fix syntax errors in a README example (@th-ad)
+
 ## 2.0.0 - 2019-05-02
 
 ### Removed

--- a/lib/rack/reducer/version.rb
+++ b/lib/rack/reducer/version.rb
@@ -2,6 +2,6 @@
 
 module Rack
   class Reducer
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end

--- a/rack-reducer.gemspec
+++ b/rack-reducer.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_path  = 'lib'
 
   spec.add_development_dependency 'actionpack', '~> 5.2'
+  spec.add_development_dependency 'activerecord', '~> 5.2'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'benchmark-memory'
   spec.add_development_dependency 'bundler', '~> 2'
@@ -26,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rubocop', '~> 0.61'
   spec.add_development_dependency 'sequel', '~> 5'
-  spec.add_development_dependency 'sqlite3', '~> 1'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   spec.add_dependency 'rack', '>= 1.6', '< 3'

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -31,7 +31,7 @@ Process.respond_to?(:fork) && RSpec.describe('in a Rails app') do
 
     Artist = Class.new(ActiveRecord::Base)
 
-    Fixtures::DB[:artists].each { |row|Artist.create(row) }
+    Fixtures::DB[:artists].each { |row| Artist.create(row) }
 
     ArtistsController = Class.new(ActionController::API) do
       RailsReducer = Rack::Reducer.new(
@@ -72,17 +72,15 @@ Process.respond_to?(:fork) && RSpec.describe('in a Rails app') do
 
   it 'tracks updates to the backend between requests' do
     pid = Process.fork do
-      res = get("/query?name=ZA")
-      expect(res.json.count).to eq(1)
+      get("/") { |res| expect(res.json.count).to eq(6) }
 
-      Artist.create!(name: "RZA", genre: "hip hop")
+      Artist.create!(name: "RZA")
 
-      res = get("/query?name=ZA")
-      expect(res.json.count).to eq(2)
+      get("/") { |res| expect(res.json.count).to eq(7) }
 
       Artist.find_by(name: "RZA").destroy
 
-      get("/query?name=ZA") { |res| expect(res.json.count).to eq(1) }
+      get("/") { |res| expect(res.json.count).to eq(6) }
     end
     Process.wait(pid)
   end


### PR DESCRIPTION
The Rails-specific specs were using a Ruby Array as a backend, not an ActiveRecord-fronted database. Because ActiveRecord is, er, kind of an important part of the Rails stack, the specs should use it. Now they do.