### PR TITLE
Use deep_symbolize_keys to transform param keys

### DIFF
--- a/lib/rack/reducer.rb
+++ b/lib/rack/reducer.rb
@@ -57,7 +57,7 @@ module Rack
         filters, params = @default_filters, EMPTY_PARAMS
       else
         # This request really does want filtering; run a full reduction
-        filters, params = @filters, url_params.to_unsafe_h.symbolize_keys
+        filters, params = @filters, url_params.to_unsafe_h.deep_symbolize_keys
       end
 
       reduce(params, filters)

--- a/lib/rack/reducer/refinements.rb
+++ b/lib/rack/reducer/refinements.rb
@@ -29,9 +29,9 @@ module Rack
       end
 
       refine Hash do
-        def symbolize_keys
+        def deep_symbolize_keys
           each_with_object({}) do |(key, val), hash|
-            hash[key.to_sym] = val.is_a?(Hash) ? val.symbolize_keys : val
+            hash[key.to_sym] = val.is_a?(Hash) ? val.deep_symbolize_keys : val
           end
         end
 

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -1,11 +1,11 @@
 module Fixtures
   DB = {
     artists: [
-      { name: 'Blake Mills', genre: 'alternative', release_count: 3 },
+      { name: 'Blake Mills', genre: 'alternative', release_count: 2 },
       { name: 'Björk', genre: 'electronic', release_count: 3 },
       { name: 'James Blake', genre: 'electronic', release_count: 3 },
-      { name: 'Janelle Monae', genre: 'alt-soul', release_count: 3 },
-      { name: 'SZA', genre: 'alt-soul', release_count: 3 },
+      { name: 'Janelle Monae', genre: 'alt-soul', release_count: 2 },
+      { name: 'SZA', genre: 'alt-soul', release_count: 1 },
       { name: 'Chris Frank', genre: 'alt-soul', release_count: nil },
     ]
   }
@@ -19,6 +19,10 @@ module Fixtures
     },
     ->(releases:) {
       select { |item| item[:release_count].to_i == releases.to_i }
+    },
+    ->(prolificacy:) {
+      range = prolificacy[:min].to_i..prolificacy[:max].to_i
+      select { |item| range.include? item[:release_count].to_i }
     },
   ]
 

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -38,6 +38,10 @@ Process.respond_to?(:fork) && RSpec.describe('in a Rails app') do
         Artist.all,
         ->(name:) { where('lower(name) like ?', "%#{name.downcase}%") },
         ->(genre:) { where(genre: genre) },
+        ->(prolificacy:) {
+          range = prolificacy[:min].to_i..prolificacy[:max].to_i
+          where(release_count: range)
+        },
       )
 
       def index
@@ -59,6 +63,9 @@ Process.respond_to?(:fork) && RSpec.describe('in a Rails app') do
   it 'works with ActionController::Parameters' do
     pid = Process.fork do
       get('/') { |res| expect(res.status).to eq(200) }
+      get('/?prolificacy[min]=2&prolificacy[max]=3') { |res|
+        expect(res.json.count).to eq(4)
+      }
     end
     Process.wait pid
   end
@@ -66,6 +73,9 @@ Process.respond_to?(:fork) && RSpec.describe('in a Rails app') do
   it 'works with request.query_parameters' do
     pid = Process.fork do
       get('/query') { |res| expect(res.status).to eq(200) }
+      get('/query?prolificacy[min]=2&prolificacy[max]=3') { |res|
+        expect(res.json.count).to eq(4)
+      }
     end
     Process.wait(pid)
   end

--- a/spec/reducer_spec.rb
+++ b/spec/reducer_spec.rb
@@ -128,9 +128,9 @@ RSpec.describe 'Rack::Reducer' do
     expect(Rack::Reducer.create({}, -> { 'hi' })).to be_a(Rack::Reducer)
   end
 
-  it 'accepts nested params' do
-    get('/artists?range[min]=1&range[max]=100') do |response|
-      expect(response.status).to eq(200)
+  it 'can filter by nested params' do
+    get('/artists?prolificacy[min]=2&prolificacy[max]=3') do |response|
+      expect(response.json.count).to eq(4)
     end
   end
 end


### PR DESCRIPTION
I just put together a simple fix for issue #13 addressing Rails's `ActionController::Parameters` / `HashWithIndifferentAccess` but also supports other implementations that rely on `Hash` by aliasing `deep_symbolize_keys` with `symbolize_keys` in the refinements.

Although `deep_symbolize_keys` might be a bit overkill here, as Rails returns `HashWithIndifferentAccess` hashes which are already responding to keys. 

Maybe a better solution would be to check for a `Hash` object first and then symbolizing the keys:

```
unsafe_params = url_params.to_unsafe_h
params = unsafe_params.is_a?(Hash) ? unsafe_params.symbolize_keys : unsafe_params
```